### PR TITLE
Adding Support for XHCI Mouse on the installation

### DIFF
--- a/src/create_cfg.py
+++ b/src/create_cfg.py
@@ -1,11 +1,4 @@
 #!/usr/bin/env python
-#
-# Copyright (c) 2013 GhostBSD
-#
-# See COPYING for licence terms.
-#
-# create_cfg.py v 1.4 Friday, January 17 2014 Eric Turgeon
-#
 
 import os
 import pickle
@@ -29,7 +22,7 @@ zfs_config = f'{tmp}/zfs_config'
 ufs_config = f'{tmp}/ufs_config'
 
 
-class gbsd_cfg():
+class GhostBSDCfg:
     def __init__(self):
         f = open(f'{tmp}/pcinstall.cfg', 'w')
         # Installation Mode
@@ -183,6 +176,9 @@ class gbsd_cfg():
             if zfs is True:
                 zfsark = "echo 'vfs.zfs.arc_max=\"512M\"' >> /boot/loader.conf"
                 f.write(f'runCommand={zfsark}\n')
+            f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
+            f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
+            f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
         else:
             f.write('\n# Network Configuration\n')
             f.write('hostname=installed\n')
@@ -196,4 +192,7 @@ class gbsd_cfg():
             f.write("runCommand=mv /usr/local/etc/devd/automount_devd"
                     "_localdisks.conf.skip /usr/local/etc/devd/"
                     "automount_devd_localdisks.conf\n")
+            f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
+            f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
+            f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
         f.close()

--- a/src/create_cfg.py
+++ b/src/create_cfg.py
@@ -176,9 +176,6 @@ class GhostBSDCfg:
             if zfs is True:
                 zfsark = "echo 'vfs.zfs.arc_max=\"512M\"' >> /boot/loader.conf"
                 f.write(f'runCommand={zfsark}\n')
-            f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
-            f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
-            f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
         else:
             f.write('\n# Network Configuration\n')
             f.write('hostname=installed\n')
@@ -192,7 +189,7 @@ class GhostBSDCfg:
             f.write("runCommand=mv /usr/local/etc/devd/automount_devd"
                     "_localdisks.conf.skip /usr/local/etc/devd/"
                     "automount_devd_localdisks.conf\n")
-            f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
-            f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
-            f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
+        f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
+        f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
+        f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
         f.close()

--- a/src/create_cfg.py
+++ b/src/create_cfg.py
@@ -192,4 +192,6 @@ class GhostBSDCfg:
         f.write("runCommand=echo '# For XHCI Mouse Support' >> /boot/loader.conf\n")
         f.write("runCommand=echo 'hw.usb.usbhid.enable=\"1\"' >> /boot/loader.conf\n")
         f.write("runCommand=echo 'usbhid_load=\"YES\"' >> /boot/loader.conf\n")
+        f.write("runCommand=echo '# For UTouch Support' >> /boot/loader.conf\n")
+        f.write("runCommand=echo 'utouch_load=\"YES\"' >> /boot/loader.conf\n")
         f.close()

--- a/src/install.py
+++ b/src/install.py
@@ -10,7 +10,7 @@ import os
 from subprocess import Popen, PIPE, STDOUT
 from time import sleep
 from partition_handler import deletePartition, destroyPartition, addPartition
-from create_cfg import gbsd_cfg
+from create_cfg import GhostBSDCfg
 import sys
 
 gbi_dir = "/usr/local/lib/gbi"
@@ -38,7 +38,7 @@ def update_progess(probar, bartext):
 
 def read_output(command, probar, main_window):
     GLib.idle_add(update_progess, probar, "Creating pcinstall.cfg")
-    gbsd_cfg()
+    GhostBSDCfg()
     sleep(1)
     if os.path.exists(f'{gbi_tmp}/delete'):
         GLib.idle_add(update_progess, probar, "Deleting partition")


### PR DESCRIPTION
## Summary by Sourcery

This pull request adds support for XHCI mice during installation and renames the `gbsd_cfg` class to `GhostBSDCfg`.

New Features:
- Adds support for XHCI (USB 3.0) mice during the installation process by enabling the `hw.usb.usbhid.enable` and loading the `usbhid` module in `/boot/loader.conf`.

Enhancements:
- Renames the `gbsd_cfg` class to `GhostBSDCfg` for clarity and consistency.