### PR TITLE
Omit da from disk query loop.

### DIFF
--- a/src/use_zfs.py
+++ b/src/use_zfs.py
@@ -275,6 +275,8 @@ class ZFS:
         self.store = Gtk.TreeStore(str, str, str, 'gboolean')
         for disk in zfs_disk_query():
             dsk = disk.partition(':')[0].rstrip()
+            if dsk.startswith("da"):
+            continue
             dsk_name = disk.partition(':')[2].rstrip()
             dsk_size = zfs_disk_size_query(dsk).rstrip()
             self.store.append(None, [dsk, dsk_size, dsk_name, False])

--- a/src/use_zfs.py
+++ b/src/use_zfs.py
@@ -276,7 +276,7 @@ class ZFS:
         for disk in zfs_disk_query():
             dsk = disk.partition(':')[0].rstrip()
             if dsk.startswith("da"):
-            continue
+                continue
             dsk_name = disk.partition(':')[2].rstrip()
             dsk_size = zfs_disk_size_query(dsk).rstrip()
             self.store.append(None, [dsk, dsk_size, dsk_name, False])


### PR DESCRIPTION
Skip any disk with a name starting with "da" in the disk query loop within src/use_zfs.py. This prevents undesired devices from appearing as selectable drives during ZFS installations, ensuring only appropriate disks are available for configuration.

## Summary by Sourcery

Bug Fixes:
- Prevents devices with names starting with 'da' from being included in the disk query loop, avoiding their display as selectable drives during ZFS installations.