### PR TITLE
Add support for detecting and doing the right thing for Gershwin users

### DIFF
--- a/src/add_users.py
+++ b/src/add_users.py
@@ -93,10 +93,8 @@ class AddUsers:
         try:
             open('/Users')
             self.sh = '/usr/local/bin/zsh'
-            shell_default = 7
         except:
             self.sh = '/usr/local/bin/fish'
-            shell_default = 3
         shell.append_text('sh')
         shell.append_text('csh')
         shell.append_text('tcsh')

--- a/src/add_users.py
+++ b/src/add_users.py
@@ -28,9 +28,9 @@ class AddUsers:
         up = self.password.get_text()
         shell = self.sh
         if os.path.isdir('/Users'):
-            if os.path.isdir('/Users'):
-        if os.path.isdir('/Users'):
-            if os.path.isdir('/Users'):	
+            hf = '/Users/%s' % self.user.get_text()
+        else:
+            hf = '/home/%s' % self.user.get_text()
         hst = self.host.get_text()
         ul = [uname, name, up, shell, hf]
 

--- a/src/add_users.py
+++ b/src/add_users.py
@@ -26,7 +26,11 @@ class AddUsers:
         name = self.name.get_text()
         up = self.password.get_text()
         shell = self.sh
-        hf = '/home/%s' % self.user.get_text()
+        try:
+            open('/Users')
+            hf = '/Users/%s' % self.user.get_text()
+        except:
+            hf = '/home/%s' % self.user.get_text()
         hst = self.host.get_text()
         ul = [uname, name, up, shell, hf]
 
@@ -86,7 +90,13 @@ class AddUsers:
         self.repassword.connect("changed", self.password_verification, button3)
         self.label5 = Gtk.Label("Shell")
         shell = Gtk.ComboBoxText()
-        self.sh = '/usr/local/bin/fish'
+        try:
+            open('/Users')
+            self.sh = '/usr/local/bin/zsh'
+            shell_default = 7
+        except:
+            self.sh = '/usr/local/bin/fish'
+            shell_default = 3
         shell.append_text('sh')
         shell.append_text('csh')
         shell.append_text('tcsh')
@@ -95,7 +105,7 @@ class AddUsers:
         shell.append_text('rbash')
         shell.append_text('ksh')
         shell.append_text('zsh')
-        shell.set_active(3)
+        shell.set_active(shell_default)
         shell.connect("changed", self.on_shell)
         label = Gtk.Label('<b>Set Hostname</b>')
         label.set_use_markup(True)

--- a/src/add_users.py
+++ b/src/add_users.py
@@ -103,7 +103,6 @@ class AddUsers:
         shell.append_text('rbash')
         shell.append_text('ksh')
         shell.append_text('zsh')
-        shell.set_active(shell_default)
         shell.connect("changed", self.on_shell)
         label = Gtk.Label('<b>Set Hostname</b>')
         label.set_use_markup(True)

--- a/src/add_users.py
+++ b/src/add_users.py
@@ -2,6 +2,7 @@
 
 from gi.repository import Gtk, Gdk
 import pickle
+import os
 from gbi_common import password_strength
 
 # Directory use from the installer.
@@ -26,11 +27,10 @@ class AddUsers:
         name = self.name.get_text()
         up = self.password.get_text()
         shell = self.sh
-        try:
-            open('/Users')
-            hf = '/Users/%s' % self.user.get_text()
-        except:
-            hf = '/home/%s' % self.user.get_text()
+        if os.path.isdir('/Users'):
+            if os.path.isdir('/Users'):
+        if os.path.isdir('/Users'):
+            if os.path.isdir('/Users'):	
         hst = self.host.get_text()
         ul = [uname, name, up, shell, hf]
 


### PR DESCRIPTION
* If /Users is detected use this for home folder during user creation
* If /Users is detected set zsh as default shell
* Otherwise it should use /home and fish as default like normal

## Summary by Sourcery

Add detection for mac-like '/Users' directory to support Gershwin users, using it for home paths and selecting zsh as the default shell when present, while retaining '/home' and fish shell as fallbacks.

New Features:
- Detect '/Users' directory and use it as the base for user home folders during user creation
- Set zsh as the default shell when '/Users' is detected and fall back to fish otherwise

Enhancements:
- Replace hardcoded home path and shell selection logic with a try/except check against '/Users'
- Use a computed shell_default index variable instead of a fixed value for setting the active shell option