### PR TITLE
Gershwin add support for /Users and zsh

### DIFF
--- a/src/add_admin.py
+++ b/src/add_admin.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from gi.repository import Gtk, Gdk
+import os
 import pickle
 from gbi_common import password_strength
 from sys_handler import set_admin_user

--- a/src/add_admin.py
+++ b/src/add_admin.py
@@ -29,7 +29,10 @@ class AddUser:
         name = self.name.get_text()
         up = self.password.get_text()
         shell = self.sh
-        hf = f'/home/{uname}'
+        if os.path.isdir('/Users'):
+          hf = f'/Users/{uname}'
+        else:
+          hf = f'/home/{uname}'
         hst = f'{uname}-ghostbsd'
         ul = [uname, name, up, shell, hf, hst]
         pickle.dump(ul, uf)
@@ -114,7 +117,10 @@ class AddUser:
         self.repassword.connect("changed", self.password_verification, button3)
         self.label5 = Gtk.Label(label="Shell")
         shell = Gtk.ComboBoxText()
-        self.sh = '/usr/local/bin/fish'
+        if os.path.isdir('/Users'):
+            self.sh = '/usr/local/bin/zsh'
+        else:
+            self.sh = '/usr/local/bin/fish'
         # Keeping this code for future project example.
         shell.append_text('sh')
         shell.append_text('csh')


### PR DESCRIPTION
* Adds support for creating new users in /Users when /Users id detected on livecd.
* Makes the default shell zsh when /Users is detected on livecd which works better with Terminal.app.

## Summary by Sourcery

Detect the presence of /Users on livecd environments and adapt user home directory paths and default shell selection accordingly

New Features:
- Automatically detect /Users directory on livecd and create user home directories in /Users when present
- Switch default shell to zsh when /Users directory is detected on livecd